### PR TITLE
Remove Ruby version from .travisci.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-rvm:
-  - 2.3.1
 script:
   - script/cibuild
 services:


### PR DESCRIPTION
As per TravisCI's documentation, it's unnecessary for the Ruby version to be set in the `.travis.yml` as there's a `.ruby-version` present in the project root. TravisCI will fall back to the version defined there in the event it's not defined in their configuration.

https://docs.travis-ci.com/user/languages/ruby/#Using-.ruby-version

/cc https://github.com/atmos/heaven/pull/200